### PR TITLE
feat: 适配 NexT 8.4.0

### DIFF
--- a/twikoo.njk
+++ b/twikoo.njk
@@ -1,9 +1,15 @@
+{{ next_data('twikoo', config.twikoo, {
+  el: '#twikoo-comments'
+}) }}
 <script>
-NexT.utils.loadComments('#twikoo-comments', () => {
-  NexT.utils.getScript('https://cdn.jsdelivr.net/npm/twikoo/dist/twikoo.all.min.js', () => {
-    twikoo.init(Object.assign({{ config.twikoo | safedump }}, {
-      el: '#twikoo-comments'
-    }));
-  }, window.twikoo);
+document.addEventListener('page:loaded', () => {
+  NexT.utils.loadComments(CONFIG.twikoo.el)
+    .then(() => NexT.utils.getScript(
+      'https://cdn.jsdelivr.net/npm/twikoo/dist/twikoo.all.min.js',
+      { condition: window.twikoo }
+    ))
+    .then(() => {
+      twikoo.init(CONFIG.twikoo);
+    });
 });
 </script>


### PR DESCRIPTION
NexT 8.4.0 会有几个不打算向后兼容的 Breaking Change，见 https://github.com/next-theme/hexo-theme-next/pull/241#issuecomment-829152144 。

此 PR 在不考虑旧版本兼容性的情况下初步适配 8.4.0，但还未经测试。可以仅作为适配参考。